### PR TITLE
fix #2 by handling out of bounds `repeat` values

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,28 @@
 module.exports = function(length) {
-    var last = null
+    var period = Math.pow(10, 2)
+    , last = -1
     , repeat = 0
+    , overflow = 0
 
     if (typeof length == 'undefined') length = 15
 
     return function() {
-        var now = Math.pow(10, 2) * +new Date()
+        var now = period * +new Date()
 
-        if (now == last) {
+        if (now <= last) {
             repeat++
+            if (repeat === period) {
+                last += period
+                overflow += period
+                repeat = 0
+            }
         } else {
             repeat = 0
             last = now
+            overflow = 0
         }
 
-        var s = (now + repeat).toString()
+        var s = (now + overflow + repeat).toString()
         return +s.substr(s.length - length)
     }
 }

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ var Nonce = require('./index')
 , expect = require('expect.js');
 
 describe('nonce', function() {
-    it('doesnt duplicate', function() {
+    it('doesnt repeat the previous nonce', function() {
         var nonce = Nonce()
         , last = null;
 
@@ -10,6 +10,16 @@ describe('nonce', function() {
             var now = nonce();
             expect(now).to.not.be(last);
             last = now;
+        }
+    })
+    it('does not output duplicate nonces', function() {
+        var nonce = Nonce()
+        , emitted = {};
+
+        for (var i = 0; i < 9999; i++) {
+            var now = nonce();
+            if (emitted[now]) throw new Error('duplicate!');
+            emitted[now] = true;
         }
     })
 })


### PR DESCRIPTION
This fixes #2 as well as the issue that I pointed out in a comment, by handling the case where `repeat` goes over 100.

Effectively when `repeat` goes over 100, a variable is bumped by 100 to indicate that we're actually generating nonces in the future. This will continue to happen until either the nonce reaches `Number.MAX_SAFE_INTEGER` or enough time passes without generating nonces.

I could've used the `%` operator to make the fix smaller, but opted to use an extra variable to represent how far into the future we're pretending to be since that is a bit more readable.

Thanks for being open to PRs :) this package has a nice name and interface and I want to use it in the future :)